### PR TITLE
fix: Remove DNT header from requests

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -3,8 +3,7 @@ const { requestFactory } = require('cozy-konnector-libs')
 const baseUrl = 'https://ael.eauxdegrenoblealpes.fr/webapi'
 const baseHeaders = {
   Host: 'ael.eauxdegrenoblealpes.fr',
-  Referer: 'https://ael.eauxdegrenoblealpes.fr/',
-  DNT: 1
+  Referer: 'https://ael.eauxdegrenoblealpes.fr/'
 }
 const request = requestFactory({
   // debug: true,


### PR DESCRIPTION
The Do Not Track header is acknowledged by Eaux de Grenoble which
opens a popup to inform the user that they do. This popup prevents the
konnector from completing.

Since we do not care about konnectors being tracked we can simply
remove it.