### PR TITLE
fix: Login and data extraction

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,5 @@
 const { log } = require('cozy-konnector-libs')
-const merge = require('lodash/merge')
-const { baseUrl, baseHeaders, request } = require('./request')
+const { baseUrl, headers, request } = require('./request')
 
 const authenticationUrl = baseUrl + '/Utilisateur/authentification'
 const tokenGenerationUrl = baseUrl + '/Acces/generateToken'
@@ -23,7 +22,7 @@ async function authenticate(login, password) {
     const response = await request({
       method: 'POST',
       uri: authenticationUrl,
-      headers: merge(baseHeaders, {
+      headers: headers({
         ConversationId: generateConversationId(),
         token: token
       }),
@@ -53,7 +52,7 @@ async function requestToken() {
     const response = await request({
       method: 'POST',
       uri: tokenGenerationUrl,
-      headers: merge(baseHeaders, {
+      headers: headers({
         ConversationId: generateConversationId(),
         Token: accessKey
       }),

--- a/src/auth.js
+++ b/src/auth.js
@@ -28,7 +28,7 @@ async function authenticate(login, password) {
       }),
       body: {
         identifiant: login,
-        motDePasseMD5: password
+        motDePasse: password
       }
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ process.env.SENTRY_DSN =
 
 
 const { log, BaseKonnector, mkdirp, saveFiles } = require('cozy-konnector-libs')
+const { posix } = require('path')
 const { authenticate } = require('./auth')
 const { fetchSubscriptions } = require('./subscriptions')
 
@@ -17,7 +18,8 @@ async function start(fields) {
 
   return Promise.all(
     (await fetchSubscriptions(token)).map(async sub => {
-      const folderPath = [fields.folderPath, sub.folderPath()].join('/')
+      await sub.fetchAddress()
+      const folderPath = posix.join(fields.folderPath, sub.folderPath())
       log('debug', { folderPath })
 
       await mkdirp(folderPath)

--- a/src/paginator.js
+++ b/src/paginator.js
@@ -1,6 +1,6 @@
 const { log } = require('cozy-konnector-libs')
 const merge = require('lodash/merge')
-const { baseHeaders, request } = require('./request')
+const { headers, request } = require('./request')
 const { generateConversationId } = require('./auth')
 
 module.exports = function Paginator(url, token, params) {
@@ -15,7 +15,7 @@ module.exports = function Paginator(url, token, params) {
         const response = await request({
           method: 'GET',
           uri: url,
-          headers: merge(baseHeaders, {
+          headers: headers({
             ConversationId: generateConversationId(),
             token
           }),

--- a/src/request.js
+++ b/src/request.js
@@ -1,10 +1,14 @@
 const { requestFactory } = require('cozy-konnector-libs')
+const merge = require('lodash/merge')
 
 const baseUrl = 'https://ael.eauxdegrenoblealpes.fr/webapi'
 const baseHeaders = {
   Host: 'ael.eauxdegrenoblealpes.fr',
   Referer: 'https://ael.eauxdegrenoblealpes.fr/'
 }
+
+const headers = extra => merge(baseHeaders, extra)
+
 const request = requestFactory({
   // debug: true,
   simple: false,
@@ -14,6 +18,6 @@ const request = requestFactory({
 
 module.exports = {
   baseUrl,
-  baseHeaders,
+  headers,
   request
 }


### PR DESCRIPTION
The login form has changed and is now expecting a `motDePasse` field
instead of a `motDePasseMD5` field.

Besides, the subscription address is not returned with the basic 
subscription info anymore when listing subscriptions.
We now fetch it separately for each subscription via the subscription
details route.
We also store the street address instead of the built address since
that is the only part we use and were extracting via a regex.